### PR TITLE
Fix remove movie method

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,9 +20,8 @@
     <MovieCard
       v-for="(movie, index) in movies"
       :key="movie.id"
-      :data-index="index"
       :movieData="movie"
-      @remove="removeMovie"
+      @remove="removeMovie(index)"
       @save="updateMovie"
     />
   </main>
@@ -148,8 +147,8 @@ export default {
       }
       this.updateLocalStorage()
     },
-    removeMovie: function( target ) {
-      this.movies.splice( target.dataIndex, 1 )
+    removeMovie: function( index ) {
+      this.movies.splice( index, 1 )
       this.updateLocalStorage()
     },
     updateLocalStorage: function() {


### PR DESCRIPTION
Awesome project Klara! I found a super small bug when deleting a movie, sometimes it grabs the wrong index. For example, deleting the second movie in the list removes the first. Might be easier to just pass the index straight to the method? :)